### PR TITLE
Add DR convenience topics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -248,12 +248,19 @@ The z component and orientation might be used in the future.
 Dead reckoning
 --------------
 
-All dead reckoning topics and nodes reside within the ``/vehicle/dr`` namespace
+All dead reckoning topics and nodes reside within the ``/vehicle/dr`` namespace.
+Note that the odometry topic may be used to construct the TF transformations.
+In general, the TF tree will be used to construct the convenience topics:
+latitude, longitude, depth, yaw, pitch and roll.
 
 **Topics**
 
 * Dead reckoning odometry (poses, velocities and uncertainties) - ``nav_msgs/Odometry`` on topic ``/vehicle/dr/odom``
 * Latitude longitude position - ``geographic_msgs/GeoPoint`` on ``/vehicle/dr/lat_lon``
+* Estimated depth - ``std_msgs/Float64`` on ``/vehicle/dr/depth``
+* Estimated yaw - ``std_msgs/Float64`` on ``/vehicle/dr/yaw``
+* Estimated pitch - ``std_msgs/Float64`` on ``/vehicle/dr/pitch``
+* Estimated roll - ``std_msgs/Float64`` on ``/vehicle/dr/roll``
 
 TF
 --


### PR DESCRIPTION
I'm testing our system for specification changes with this PR.

Description
=========
Adds more convenience topics constructed from the TF (coming from dead reckoning):

* Estimated depth - ``std_msgs/Float64`` on ``/vehicle/dr/depth``
* Estimated yaw - ``std_msgs/Float64`` on ``/vehicle/dr/yaw``
* Estimated pitch - ``std_msgs/Float64`` on ``/vehicle/dr/pitch``
* Estimated roll - ``std_msgs/Float64`` on ``/vehicle/dr/roll``

This is inline with the ``/vehicle/dr/lat_lon`` topic from before.

Impact
=====
Should be pretty uncontroversial, @svbhat will add a package that does this for us.

Can @nistenius , @NiklasRolleberg , @svbhat and @Jollerprutt comment to show that you agree (or disagree) to the change.