### PR TITLE
Added GotoWaypoint message 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ add_message_files(
   DVLBeam.msg
   DVL.msg
   LatLonOdometry.msg
+  GotoWaypoint.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/msg/GotoWaypoint.msg
+++ b/msg/GotoWaypoint.msg
@@ -1,0 +1,26 @@
+# target pose in local UTM zone ENU coordinates
+# UTM zone used defined by global
+# /utm_zone and /utm_band ROS params
+geometry_msgs/PoseStamped waypoint_pose
+# required proximity in meters to waypoint in
+# order to consider the waypoint as reached
+# (should be at least 1m)
+float64 goal_tolerance
+
+# Defines the type of z control used going there
+uint8 Z_CONTROL_NONE = 0
+uint8 Z_CONTROL_DEPTH = 1
+uint8 Z_CONTROL_ALTITUDE = 2
+
+uint8 z_control_mode
+float64 travel_altitude
+float64 travel_depth
+
+# Defines the type of speed control used going there
+uint8 SPEED_CONTROL_NONE = 0
+uint8 SPEED_CONTROL_RPM = 1
+uint8 SPEED_CONTROL_SPEED = 2
+
+uint8 speed_control_mode
+float64 travel_rpm
+float64 travel_speed


### PR DESCRIPTION
Mimics the GotoWaypoint action goal. Enables the BT to receive waypoints from outside and execute them at arbitrary points during a planned mission. If there is no plan given, the WP is executed directly.